### PR TITLE
Make the material importing tool search for textures in both the parent directory and 'textures/' subfolder.

### DIFF
--- a/goldsrc/importmat.py
+++ b/goldsrc/importmat.py
@@ -1,5 +1,4 @@
 import bpy
-import os
 
 from ..utils import Popup, FindOrMakeNodeByLabel
 

--- a/goldsrc/importmat.py
+++ b/goldsrc/importmat.py
@@ -1,4 +1,5 @@
 import bpy
+import os
 
 from ..utils import Popup, FindOrMakeNodeByLabel
 
@@ -18,11 +19,27 @@ def FixImportMaterials():
 		texturenode = FindOrMakeNodeByLabel(mat.node_tree.nodes, "ShaderNodeTexImage", "Albedo", (-300.0, 218.0))
 		
 		texturepath = f"//{mat.name}"
+		texturepathwithsubfolder = f"//textures/{mat.name}"
+		#this helps with error handling when loading the textures
+		textureerrors = 0
 		try:
 			texture = bpy.data.images.load(texturepath, check_existing=True)
 		except Exception as e:
+			textureerrors += 1
+		
+		try:
+			texture = bpy.data.images.load(texturepathwithsubfolder, check_existing=True)
+		except:
+			textureerrors += 1
+			
+		
+		if textureerrors > 1:
 			Popup(message=f"Can't load image: {texturepath}!", title="Error", icon="ERROR")
 			print(f"Can't load image: {texturepath}!\n{e}")
+			return False
+
+			Popup(message=f"Can't load image: {texturepathwithsubfolder}!", title="Error", icon="ERROR")
+			print(f"Can't load image: {texturepathwithsubfolder}!\n{e}")
 			return False
 		
 		texturenode.image = texture

--- a/goldsrc/importmat.py
+++ b/goldsrc/importmat.py
@@ -1,18 +1,21 @@
 import bpy
+import os.path
 
 from ..utils import Popup, FindOrMakeNodeByLabel
 
 #TODO: make both functions call the mat.py ones for node setups
 
-def findTexture():
-	texturepaths = [f"//{mat.name}", f"//textures/{mat.name}"]
-	for p in texturepaths:
-		try:
-			texture = bpy.data.images.load(p, check_existing=True)
-			return p
-		except:
-			pass
-	return texturepaths[0]
+def FindTexture(mat):
+	#uppercase variants because unix land :weary:
+	subPaths = ["", "textures", "texture", "Textures", "Texture"]
+	for subPath in subPaths:
+		potentialPath = bpy.path.abspath(os.path.join("//", subPath, mat.name))
+		if not os.path.isfile(potentialPath):
+			continue
+
+		return potentialPath
+
+	return None
 
 def FixImportMaterials():
 	if not bpy.data.is_saved:
@@ -27,7 +30,12 @@ def FixImportMaterials():
 		
 		texturenode = FindOrMakeNodeByLabel(mat.node_tree.nodes, "ShaderNodeTexImage", "Albedo", (-300.0, 218.0))
 		
-		texturepath = findTexture()
+		texturepath = FindTexture(mat)
+		if texturepath is None:
+			Popup(message=f"Couldn't find texture: {mat.name}!", title="Error", icon="ERROR")
+			print(f"Couldn't find texture: {mat.name}!")
+			return False
+
 		try:
 			texture = bpy.data.images.load(texturepath, check_existing=True)
 		except Exception as e:
@@ -92,7 +100,12 @@ def FixImportAllMaterials():
 				
 				texturenode = FindOrMakeNodeByLabel(mat.node_tree.nodes, "ShaderNodeTexImage", "Albedo", (-300.0, 218.0))
 				
-				texturepath = findTexture()
+				texturepath = FindTexture()
+				if texturepath is None:
+					Popup(message=f"Couldn't find texture: {mat.name}!", title="Error", icon="ERROR")
+					print(f"Couldn't find texture: {mat.name}!")
+					return False
+		
 				try:
 					texture = bpy.data.images.load(texturepath, check_existing=True)
 				except Exception as e:

--- a/goldsrc/importmat.py
+++ b/goldsrc/importmat.py
@@ -4,6 +4,16 @@ from ..utils import Popup, FindOrMakeNodeByLabel
 
 #TODO: make both functions call the mat.py ones for node setups
 
+def findTexture():
+	texturepaths = [f"//{mat.name}", f"//textures/{mat.name}"]
+	for p in texturepaths:
+		try:
+			texture = bpy.data.images.load(p, check_existing=True)
+			return p
+		except:
+			pass
+	return texturepaths[0]
+
 def FixImportMaterials():
 	if not bpy.data.is_saved:
 		Popup(message="File must be saved for relative paths!", title="Error", icon="ERROR")
@@ -17,31 +27,12 @@ def FixImportMaterials():
 		
 		texturenode = FindOrMakeNodeByLabel(mat.node_tree.nodes, "ShaderNodeTexImage", "Albedo", (-300.0, 218.0))
 		
-		texturepath = f"//{mat.name}"
-		texturepathwithsubfolder = f"//textures/{mat.name}"
-		#this helps with error handling when loading the textures
-		textureerrors = 0
-		exception = ""
-		exceptionsubfolder = ""
+		texturepath = findTexture()
 		try:
 			texture = bpy.data.images.load(texturepath, check_existing=True)
 		except Exception as e:
-			textureerrors += 1
-			exception = e
-		
-		try:
-			texture = bpy.data.images.load(texturepathwithsubfolder, check_existing=True)
-		except Exception as e:
-			textureerrors += 1
-			exceptionsubfolder = e
-		
-		if textureerrors > 1:
 			Popup(message=f"Can't load image: {texturepath}!", title="Error", icon="ERROR")
-			print(f"Can't load image: {texturepath}!\n{exception}")
-			return False
-
-			Popup(message=f"Can't load image: {texturepathwithsubfolder}!", title="Error", icon="ERROR")
-			print(f"Can't load image: {texturepathwithsubfolder}!\n{exceptionsubfolder}")
+			print(f"Can't load image: {texturepath}!\n{e}")
 			return False
 		
 		texturenode.image = texture
@@ -101,7 +92,7 @@ def FixImportAllMaterials():
 				
 				texturenode = FindOrMakeNodeByLabel(mat.node_tree.nodes, "ShaderNodeTexImage", "Albedo", (-300.0, 218.0))
 				
-				texturepath = f"//{mat.name}"
+				texturepath = findTexture()
 				try:
 					texture = bpy.data.images.load(texturepath, check_existing=True)
 				except Exception as e:

--- a/goldsrc/importmat.py
+++ b/goldsrc/importmat.py
@@ -22,24 +22,27 @@ def FixImportMaterials():
 		texturepathwithsubfolder = f"//textures/{mat.name}"
 		#this helps with error handling when loading the textures
 		textureerrors = 0
+		exception = ""
+		exceptionsubfolder = ""
 		try:
 			texture = bpy.data.images.load(texturepath, check_existing=True)
 		except Exception as e:
 			textureerrors += 1
+			exception = e
 		
 		try:
 			texture = bpy.data.images.load(texturepathwithsubfolder, check_existing=True)
-		except:
+		except Exception as e:
 			textureerrors += 1
-			
+			exceptionsubfolder = e
 		
 		if textureerrors > 1:
 			Popup(message=f"Can't load image: {texturepath}!", title="Error", icon="ERROR")
-			print(f"Can't load image: {texturepath}!\n{e}")
+			print(f"Can't load image: {texturepath}!\n{exception}")
 			return False
 
 			Popup(message=f"Can't load image: {texturepathwithsubfolder}!", title="Error", icon="ERROR")
-			print(f"Can't load image: {texturepathwithsubfolder}!\n{e}")
+			print(f"Can't load image: {texturepathwithsubfolder}!\n{exceptionsubfolder}")
 			return False
 		
 		texturenode.image = texture


### PR DESCRIPTION
The title of this pull request should be self-explanatory, but I think it's better to include some additional context into why I'd like this change to be merged.

As you know, most decompilers for GoldSRC will place textures in the same place as the model data, however a couple of decompilers, most notably the Xash3D MDLdec binary, will place textures in a subfolder by default. This subfolder is usually named 'textures' in lowercase. If anyone were to use the material importer with this kind of output, they would have to place the blend file in the textures folder, which isn't exactly ideal.

This small change I've made will make it so the material importer will search for textures in both the parent directory and the textures subfolder, so anyone that uses the Xash3D decompiler can have the material importer find the textures properly while having their blend file outside the subfolder. I've also made it so the material importer will only throw a 'Can't load image' error if it can't find the supposed texture inside the parent directory and the textures subfolder.